### PR TITLE
Allow infinite arguments from query window

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ This is a port of the Wox plugin [Runner](https://github.com/jessebarocio/Wox.Pl
 
 This port is intended to be used for [Flow Launcher](https://github.com/Flow-Launcher/Flow.Launcher). It will not work for Wox.
 
+New: Use {0} in your setting argument to allow infinite arguments passed through the query window. For this to work the setting argument needs to end with {0}
+
 To use this plugin, from your Flow Launcher search `pm install runner`
 
 Changes contained in this port:

--- a/Wox.Plugin.Runner/Runner.cs
+++ b/Wox.Plugin.Runner/Runner.cs
@@ -26,7 +26,20 @@ namespace Wox.Plugin.Runner
             var results = new List<Result>();
 
             if (string.IsNullOrEmpty(query.Search))
-                return results;
+            {
+                return
+                    RunnerConfiguration.Commands
+                    .Select(c =>
+                        new Result()
+                        {
+                            Score = 50,
+                            Title = "Run " + (c.Description ?? $"shortcut {c.Shortcut}"),
+                            SubTitle = c.Description,
+                            Action = e => RunCommand(e, new List<string>(), c),
+                            IcoPath = c.Path
+                        })
+                    .ToList();
+            }
 
             var search = query.Search;
 
@@ -36,7 +49,7 @@ namespace Wox.Plugin.Runner
 
             var terms = splittedSearch[1..];
 
-            var matches = 
+            return
                 RunnerConfiguration.Commands
                 .Where(c => c.Shortcut == shortcut)
                 .Select(c => 
@@ -48,8 +61,8 @@ namespace Wox.Plugin.Runner
                         SubTitle = c.Description,
                         Action = e => RunCommand(e, terms, c),
                         IcoPath = c.Path
-                    });
-            return matches.ToList();
+                    })
+                .ToList();
         }
 
         public Control CreateSettingPanel()

--- a/Wox.Plugin.Runner/Runner.cs
+++ b/Wox.Plugin.Runner/Runner.cs
@@ -85,8 +85,18 @@ namespace Wox.Plugin.Runner
         private ProcessArguments GetProcessArguments( Command c, IEnumerable<string> terms )
         {
             var argString = string.Empty;
-            if ( !string.IsNullOrEmpty( c.ArgumentsFormat ) )
-                argString = string.Format(c.ArgumentsFormat, terms.ToArray());
+
+            if (!string.IsNullOrEmpty(c.ArgumentsFormat))
+            {
+                if (c.ArgumentsFormat.EndsWith("{*}"))
+                {
+                    argString = c.ArgumentsFormat.Remove(c.ArgumentsFormat.Length-3, 3) + string.Join(" ", terms);
+                }
+                else 
+                {
+                    argString = string.Format(c.ArgumentsFormat, terms.ToArray());
+                }
+            }
 
             var workingDir = c.WorkingDirectory;
             if (string.IsNullOrEmpty(workingDir)) {

--- a/Wox.Plugin.Runner/plugin.json
+++ b/Wox.Plugin.Runner/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Plugin Runner",
   "Description": "Create simple command shortcuts",
   "Author": "Jesse Barocio (@jessebarocio)",
-  "Version": "2.0.2",
+  "Version": "2.1.0",
   "Language": "csharp",
   "Website": "https://github.com/jjw24/Wox.Plugin.Runner",
   "IcoPath": "Images\\gear.png",


### PR DESCRIPTION
- use {0} at the end of argument setting to allow passing through additional infinite arguments via the query window
- list all commands when no query is typed