### PR TITLE
Improve handling of duplicate keywords with different numbers of parameters

### DIFF
--- a/Wox.Plugin.Runner/Command.cs
+++ b/Wox.Plugin.Runner/Command.cs
@@ -21,7 +21,7 @@ namespace Wox.Plugin.Runner
             {
                 if (ArgumentsFormat == null) return 0;
 
-                // this is the "unlimited" terms symbol
+                // arbitrarily high count for correctish ordering
                 if (UnlimitedTerms)
                 {
                   return 20;

--- a/Wox.Plugin.Runner/Command.cs
+++ b/Wox.Plugin.Runner/Command.cs
@@ -10,6 +10,11 @@ namespace Wox.Plugin.Runner
         public string WorkingDirectory { get; set; } = "";
         public string ArgumentsFormat { get; set; } = "";
 
+        public bool UnlimitedTerms
+        {
+          get { return ArgumentsFormat != null && ArgumentsFormat.Contains("{*}"); }
+        }
+
         public int TermsCount
         {
             get
@@ -17,9 +22,9 @@ namespace Wox.Plugin.Runner
                 if (ArgumentsFormat == null) return 0;
 
                 // this is the "unlimited" terms symbol
-                if (ArgumentsFormat.Contains("{*}"))
+                if (UnlimitedTerms)
                 {
-                  return 50;
+                  return 20;
                 }
 
                 // return the number of {} terms

--- a/Wox.Plugin.Runner/Command.cs
+++ b/Wox.Plugin.Runner/Command.cs
@@ -1,16 +1,30 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Text.RegularExpressions;
 
 namespace Wox.Plugin.Runner
 {
-    public class Command
+  public class Command
     {
         public string Shortcut { get; set; } = "";
         public string Description { get; set; } = "";
         public string Path { get; set; } = "";
         public string WorkingDirectory { get; set; } = "";
         public string ArgumentsFormat { get; set; } = "";
+
+        public int TermsCount
+        {
+            get
+            {
+                if (ArgumentsFormat == null) return 0;
+
+                // this is the "unlimited" terms symbol
+                if (ArgumentsFormat.Contains("{*}"))
+                {
+                  return 50;
+                }
+
+                // return the number of {} terms
+                return Regex.Matches(ArgumentsFormat, "{.*?}").Count;
+            }
+        }
     }
 }

--- a/Wox.Plugin.Runner/Runner.cs
+++ b/Wox.Plugin.Runner/Runner.cs
@@ -56,14 +56,16 @@ namespace Wox.Plugin.Runner
                 var terms = splittedSearch[1..];
 
                 // exact match found and shows to the user command is being run with arguments
-                // score gets a boost if the terms length is equal to the terms count in the command
-                // otherwise sorted from least number of valid terms upwards (so if you have a command with the same
-                // shortcut with 1,2,3,* terms and the user types 2 terms, "1" will be deprioritized, and 2,3,* will
-                // be sorted in that order.
+                // score gets a boost based on how close the number of terms match. For example, if you have 3
+                // identical keywords, each with a different number of parameters then they will be sorted based on
+                // closeness to the number of parameters the user has typed.
+                //
+                // for example if the user types `pt hello there`, then a {0} and {1} version will have the lowest ranking
+                // while the version with {2} will have the highest, followed by {3}, {4}...{*}.
                 results = RunnerConfiguration.Commands.Where(c => c.Shortcut == shortcut)
                     .Select(c => new Result()
                     {
-                        Score = 50 + (terms.Length <= c.TermsCount ? -c.TermsCount : c.TermsCount),
+                        Score = 50 + (terms.Length <= c.TermsCount ? terms.Length - c.TermsCount : -50),
                         Title = "Run " + (c.Description ?? $"shortcut {c.Shortcut}") +
                                 (terms.Count() > 0 ? $" with arguments: {string.Join(" ", terms)}" : string.Empty),
                         SubTitle = c.Description,

--- a/Wox.Plugin.Runner/Runner.cs
+++ b/Wox.Plugin.Runner/Runner.cs
@@ -56,10 +56,14 @@ namespace Wox.Plugin.Runner
                 var terms = splittedSearch[1..];
 
                 // exact match found and shows to the user command is being run with arguments
+                // score gets a boost if the terms length is equal to the terms count in the command
+                // otherwise sorted from least number of valid terms upwards (so if you have a command with the same
+                // shortcut with 1,2,3,* terms and the user types 2 terms, "1" will be deprioritized, and 2,3,* will
+                // be sorted in that order.
                 results = RunnerConfiguration.Commands.Where(c => c.Shortcut == shortcut)
                     .Select(c => new Result()
                     {
-                        Score = 50,
+                        Score = 50 + (terms.Length <= c.TermsCount ? -c.TermsCount : c.TermsCount),
                         Title = "Run " + (c.Description ?? $"shortcut {c.Shortcut}") +
                                 (terms.Count() > 0 ? $" with arguments: {string.Join(" ", terms)}" : string.Empty),
                         SubTitle = c.Description,
@@ -133,12 +137,10 @@ namespace Wox.Plugin.Runner
             if (!string.IsNullOrEmpty(c.ArgumentsFormat))
             {
                 // command's arguments HAS an infinite flag, thus user is able to manually pass infinite amount of arguments
-                if (c.ArgumentsFormat.EndsWith("{*}"))
+                if (c.ArgumentsFormat.Contains("{*}"))
                 {   
-                    // remove '{*}' flag from arguments
-                    argString = c.ArgumentsFormat.Remove(c.ArgumentsFormat.Length - 3, 3);
                     // add user specified arguments to the arguments to be passed
-                    argString += terms != null ? string.Join(" ", terms) : "";
+                    argString = c.ArgumentsFormat.Replace("{*}", terms != null ? string.Join(" ", terms) : "");
                 }
                 // command's arguments HAS flag/s, thus user is able to manually pass in arguments e.g. settings: {0} {1}
                 // or command's arguments HAS set normal text arguments e.g. settings: -h myremotecomp -p 22

--- a/Wox.Plugin.Runner/Settings/RunnerSettings.xaml.cs
+++ b/Wox.Plugin.Runner/Settings/RunnerSettings.xaml.cs
@@ -48,7 +48,7 @@ namespace Wox.Plugin.Runner.Settings
 
         private void btnSaveChanges_Click(object sender, RoutedEventArgs e)
         {
-            if (viewModel.Commands.Any(c => string.IsNullOrEmpty(c.Shortcut) || string.IsNullOrEmpty(c.Path)))
+            if (viewModel.Commands != null && viewModel.Commands.Any(c => string.IsNullOrEmpty(c.Shortcut) || string.IsNullOrEmpty(c.Path)))
             {
                 MessageBox.Show("One or more commands is missing a Shortcut or Path. Set a Shortcut and Path and try again.", "", 
                             MessageBoxButtons.OK, MessageBoxIcon.Warning);

--- a/Wox.Plugin.Runner/plugin.json
+++ b/Wox.Plugin.Runner/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Plugin Runner",
   "Description": "Create simple command shortcuts",
   "Author": "Jesse Barocio (@jessebarocio)",
-  "Version": "2.3.0",
+  "Version": "2.3.1",
   "Language": "csharp",
   "Website": "https://github.com/jjw24/Wox.Plugin.Runner",
   "IcoPath": "Images\\gear.png",


### PR DESCRIPTION
This change introduces the following changes:

1. {*} can now be anywhere in the command. This is particularly useful if commands need to encase the parameters in quotes (for example, when constructing a URL to pass to a browser you might use `"https://example.com/{*}"`. Without the `"` the browser would see the URL with the first argument as 1 argument and subsequent arguments as separate arguments.
2. Better ordering of search results when there is a duplicated keyword with different amounts of parameters. For example, if I have `pt {0}`, `pt {0} {1}` and `pt {*}` then these will be ordered correctly (by increasing parameters) and as you type the most appropriate option will be the first one. 
3. Removes a weird "potential null" build warning