### PR TITLE
Add the feature to run a command as administrator

### DIFF
--- a/Wox.Plugin.Runner/Runner.cs
+++ b/Wox.Plugin.Runner/Runner.cs
@@ -116,6 +116,12 @@ namespace Wox.Plugin.Runner
                 {
                     UseShellExecute = true
                 };
+                
+                if (command.RunAsAdministrator)
+                {
+                    startInfo.Verb = "runas";
+                }
+                
                 if (args.WorkingDirectory != null)
                 {
                     startInfo.WorkingDirectory = args.WorkingDirectory;

--- a/Wox.Plugin.Runner/Settings.cs
+++ b/Wox.Plugin.Runner/Settings.cs
@@ -10,6 +10,7 @@ namespace Wox.Plugin.Runner
         public string Path { get; set; } = "";
         public string WorkingDirectory { get; set; } = "";
         public string ArgumentsFormat { get; set; } = "";
+        public bool RunAsAdministrator { get; set; } = false;
 
         public bool UnlimitedTerms
         {

--- a/Wox.Plugin.Runner/ViewModel/CommandViewModel.cs
+++ b/Wox.Plugin.Runner/ViewModel/CommandViewModel.cs
@@ -11,6 +11,7 @@ namespace Wox.Plugin.Runner.ViewModel
             path = command.Path;
             workingDirectory = command.WorkingDirectory;
             argumentsFormat = command.ArgumentsFormat;
+            runAsAdministrator = command.RunAsAdministrator;
         }
 
         public Command Command { get; set; }
@@ -85,6 +86,20 @@ namespace Wox.Plugin.Runner.ViewModel
             }
         }
 
+        private bool runAsAdministrator;
+        public bool RunAsAdministrator
+        {
+            get
+            {
+                return runAsAdministrator;
+            }
+            set
+            {
+                runAsAdministrator = value;
+                CheckDirty();
+            }
+        }
+
         public bool IsDirty { get; set; } = false;
 
         public Command GetCommand()
@@ -98,7 +113,8 @@ namespace Wox.Plugin.Runner.ViewModel
                     Shortcut = Shortcut,
                     Path = Path,
                     WorkingDirectory = WorkingDirectory,
-                    ArgumentsFormat = ArgumentsFormat
+                    ArgumentsFormat = ArgumentsFormat,
+                    RunAsAdministrator = RunAsAdministrator
                 };
         }
 
@@ -109,7 +125,8 @@ namespace Wox.Plugin.Runner.ViewModel
                 ( Shortcut != Command.Shortcut ) ||
                 ( Path != Command.Path ) ||
                 ( WorkingDirectory != Command.WorkingDirectory ) ||
-                ( ArgumentsFormat != Command.ArgumentsFormat );
+                ( ArgumentsFormat != Command.ArgumentsFormat ) ||
+                ( RunAsAdministrator != Command.RunAsAdministrator );
         }
     }
 }

--- a/Wox.Plugin.Runner/ViewModel/RunnerSettings.xaml
+++ b/Wox.Plugin.Runner/ViewModel/RunnerSettings.xaml
@@ -74,6 +74,7 @@
                     <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
+                    <RowDefinition />
                 </Grid.RowDefinitions>
                 <Label
                     Grid.Row="0"
@@ -157,20 +158,31 @@
                         Use {explorer} to use the currently open file explorer window's path
                     </TextBlock>
                 </StackPanel>
-                <Label
+                <CheckBox
                     Grid.Row="7"
+                    Grid.Column="1"
+                    Margin="5,10,10,0"
+                    VerticalAlignment="Top"
+                    Content="Run as Administrator"
+                    IsChecked="{Binding SelectedCommand.RunAsAdministrator, UpdateSourceTrigger=PropertyChanged}">
+                    <CheckBox.ToolTip>
+                        <TextBlock Text="Requires User Account Control (UAC) elevation" />
+                    </CheckBox.ToolTip>
+                </CheckBox>
+                <Label
+                    Grid.Row="8"
                     Margin="5,10,0,0"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Top"
                     Content="Arguments:" />
                 <TextBox
-                    Grid.Row="7"
+                    Grid.Row="8"
                     Grid.Column="1"
                     Height="23"
                     Margin="5,10,10,0"
                     VerticalAlignment="Top"
                     Text="{Binding SelectedCommand.ArgumentsFormat, UpdateSourceTrigger=PropertyChanged}" />
-                <StackPanel Grid.Row="8" Grid.Column="1">
+                <StackPanel Grid.Row="9" Grid.Column="1">
                     <TextBlock
                         Margin="5,10,0,0"
                         HorizontalAlignment="Left"

--- a/Wox.Plugin.Runner/plugin.json
+++ b/Wox.Plugin.Runner/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Plugin Runner",
   "Description": "Create simple command shortcuts",
   "Author": "Jesse Barocio (@jessebarocio)",
-  "Version": "2.4.0",
+  "Version": "2.5.0",
   "Language": "csharp",
   "Website": "https://github.com/jjw24/Wox.Plugin.Runner",
   "IcoPath": "Images\\gear.png",


### PR DESCRIPTION
This PR adds the ability to run commands with administrator privileges (UAC elevation).

### Changes:
- Added `RunAsAdministrator` boolean property to command settings
- Added checkbox in settings UI to enable/disable admin mode per command
- Commands with admin enabled will trigger UAC prompt when executed
- Gracefully handles UAC cancellation (existing error handling)

### Implementation:
- Uses Windows `runas` verb for process elevation
- Minimal changes to core functionality
- Settings persist in existing JSON storage

### Usage:
In plugin settings, check "Run as Administrator" for any command that requires elevated privileges (e.g., registry editor, system configuration tools).