### PR TITLE
Fix working directory error when not set

### DIFF
--- a/Wox.Plugin.Runner/Runner.cs
+++ b/Wox.Plugin.Runner/Runner.cs
@@ -145,7 +145,8 @@ public class Runner : IPlugin, ISettingProvider
                 UseShellExecute = true
             };
 
-            if (command.RunAsAdministrator) startInfo.Verb = "runas";
+            if (command.RunAsAdministrator)
+                startInfo.Verb = "runas";
 
             // Working directory if set via settings will be args.WorkingDirectory
             // If not set, args.WorkingDirectory will default to the directory of the executable

--- a/Wox.Plugin.Runner/Runner.cs
+++ b/Wox.Plugin.Runner/Runner.cs
@@ -147,21 +147,18 @@ public class Runner : IPlugin, ISettingProvider
 
             if (command.RunAsAdministrator) startInfo.Verb = "runas";
 
-            // Only validate working directory if one was explicitly configured by the user
-            if (!string.IsNullOrEmpty(command.WorkingDirectory) && !string.IsNullOrEmpty(args.WorkingDirectory))
+            // Working directory if set via settings will be args.WorkingDirectory
+            // If not set, args.WorkingDirectory will default to the directory of the executable
+            if (Directory.Exists(args.WorkingDirectory))
             {
-                // Validate working directory exists
-                if (!Directory.Exists(args.WorkingDirectory))
-                {
-                    Context.API.ShowMsg("Error: Working Directory Not Found",
-                        $"The working directory does not exist:\n{args.WorkingDirectory}\n\n" +
-                        $"The command will run without a specific working directory.");
-                    Context.API.LogWarn(nameof(Runner), $"Working directory not found: {args.WorkingDirectory}");
-                }
-                else
-                {
-                    startInfo.WorkingDirectory = args.WorkingDirectory;
-                }
+                startInfo.WorkingDirectory = args.WorkingDirectory;
+            }
+            else
+            {
+                Context.API.ShowMsg("Error: Working Directory Not Found",
+                    $"The working directory does not exist:\n{args.WorkingDirectory}\n\n" +
+                    $"The command will run from the plugin's directory.");
+                Context.API.LogWarn(nameof(Runner), $"Working directory not found: {args.WorkingDirectory}");
             }
 
             Process.Start(startInfo);

--- a/Wox.Plugin.Runner/Runner.cs
+++ b/Wox.Plugin.Runner/Runner.cs
@@ -158,7 +158,7 @@ public class Runner : IPlugin, ISettingProvider
             {
                 Context.API.ShowMsg("Error: Working Directory Not Found",
                     $"The working directory does not exist:\n{args.WorkingDirectory}\n\n" +
-                    $"The command will run from the plugin's directory.");
+                    $"The command will run from the application's directory instead.");
                 Context.API.LogWarn(nameof(Runner), $"Working directory not found: {args.WorkingDirectory}");
             }
 

--- a/Wox.Plugin.Runner/plugin.json
+++ b/Wox.Plugin.Runner/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Plugin Runner",
   "Description": "Create simple command shortcuts",
   "Author": "Jesse Barocio (@jessebarocio)",
-  "Version": "2.6.1",
+  "Version": "2.6.2",
   "Language": "csharp",
   "Website": "https://github.com/jjw24/Wox.Plugin.Runner",
   "IcoPath": "Images\\gear.png",


### PR DESCRIPTION
When working directory is not set, Runner uses the application directory instead of the directory of the executable. This is not the expected behaviour.

This change simplifies logic and if working directory not set then directory of the executable will be used.