### PR TITLE
Fix multi-command saving

### DIFF
--- a/Wox.Plugin.Runner/ViewModel/CommandViewModel.cs
+++ b/Wox.Plugin.Runner/ViewModel/CommandViewModel.cs
@@ -102,8 +102,6 @@ public sealed class CommandViewModel : INotifyPropertyChanged
 
     public Command GetCommand()
     {
-        if (!IsDirty)
-            return Command;
         return new Command
         {
             Description = Description,

--- a/Wox.Plugin.Runner/plugin.json
+++ b/Wox.Plugin.Runner/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Plugin Runner",
   "Description": "Create simple command shortcuts",
   "Author": "Jesse Barocio (@jessebarocio)",
-  "Version": "2.6.3",
+  "Version": "2.6.4",
   "Language": "csharp",
   "Website": "https://github.com/jjw24/Wox.Plugin.Runner",
   "IcoPath": "Images\\gear.png",


### PR DESCRIPTION
Fix issue where saving multiple commands does not work- second command resets after the first command is saved.