### PR TITLE
Fix Directory not found for URL paths

### DIFF
--- a/Wox.Plugin.Runner/Runner.cs
+++ b/Wox.Plugin.Runner/Runner.cs
@@ -255,7 +255,9 @@ public class Runner : IPlugin, ISettingProvider
             workingDir = openExplorerPaths.FirstOrDefault();
         }
 
-        if (string.IsNullOrEmpty(workingDir))
+        // A URL has no local directory, so deriving one would produce an invalid
+        // working directory (triggering a "Working Directory Not Found" warning).
+        if (string.IsNullOrEmpty(workingDir) && !IsUrl(c.Path))
             // Use directory where executable is based.
             workingDir = Path.GetDirectoryName(c.Path);
 
@@ -266,6 +268,9 @@ public class Runner : IPlugin, ISettingProvider
             WorkingDirectory = workingDir
         };
     }
+
+    private static bool IsUrl(string path)
+        => Uri.TryCreate(path, UriKind.Absolute, out var uri) && !uri.IsFile;
 
     private sealed class ProcessArguments
     {

--- a/Wox.Plugin.Runner/Runner.cs
+++ b/Wox.Plugin.Runner/Runner.cs
@@ -163,7 +163,7 @@ public class Runner : IPlugin, ISettingProvider
             {
                 startInfo.WorkingDirectory = args.WorkingDirectory;
             }
-            else if (!string.IsNullOrEmpty(args.WorkingDirectory))
+            else if (!string.IsNullOrWhiteSpace(args.WorkingDirectory))
             {
                 // Only warn when a working directory was actually resolved but does not exist on disk.
                 Context.API.ShowMsg("Error: Working Directory Not Found",
@@ -259,7 +259,7 @@ public class Runner : IPlugin, ISettingProvider
 
         // A URL has no local directory, so deriving one would produce an invalid
         // working directory (triggering a "Working Directory Not Found" warning).
-        if (string.IsNullOrEmpty(workingDir) && !IsUrl(c.Path))
+        if (string.IsNullOrWhiteSpace(workingDir) && !IsUrl(c.Path))
             // Use directory where executable is based.
             workingDir = Path.GetDirectoryName(c.Path);
 

--- a/Wox.Plugin.Runner/Runner.cs
+++ b/Wox.Plugin.Runner/Runner.cs
@@ -156,14 +156,16 @@ public class Runner : IPlugin, ISettingProvider
             if (command.RunAsAdministrator)
                 startInfo.Verb = "runas";
 
-            // Working directory if set via settings will be args.WorkingDirectory
-            // If not set, args.WorkingDirectory will default to the directory of the executable
+            // Working directory if set via settings will be args.WorkingDirectory.
+            // If not set (e.g. when the command path is a URL), args.WorkingDirectory will be
+            // empty and the process simply runs from the application's directory.
             if (Directory.Exists(args.WorkingDirectory))
             {
                 startInfo.WorkingDirectory = args.WorkingDirectory;
             }
-            else
+            else if (!string.IsNullOrEmpty(args.WorkingDirectory))
             {
+                // Only warn when a working directory was actually resolved but does not exist on disk.
                 Context.API.ShowMsg("Error: Working Directory Not Found",
                     $"The working directory does not exist:\n{args.WorkingDirectory}\n\n" +
                     $"The command will run from the application's directory instead.");

--- a/Wox.Plugin.Runner/plugin.json
+++ b/Wox.Plugin.Runner/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Plugin Runner",
   "Description": "Create simple command shortcuts",
   "Author": "Jesse Barocio (@jessebarocio)",
-  "Version": "2.6.5",
+  "Version": "2.6.6",
   "Language": "csharp",
   "Website": "https://github.com/jjw24/Wox.Plugin.Runner",
   "IcoPath": "Images\\gear.png",


### PR DESCRIPTION
Skip deriving a working directory when the command path is a URL, which otherwise caused a "Directory not found" error.